### PR TITLE
Fix options for turning off mining damage.

### DIFF
--- a/Source/ClassLibrary1/ModSettings.cs
+++ b/Source/ClassLibrary1/ModSettings.cs
@@ -29,11 +29,11 @@ namespace DamageMotes
             list.End();
         }
 
-        public bool ShouldDisplayDamageAccordingToSettings(Thing t)
+        public bool ShouldDisplayDamageAccordingToSettings(Thing target, Thing instigator)
         {
-            if (!EnableIndicatorNeutralFaction && t.Faction == null)
+            if (!EnableIndicatorNeutralFaction && (target.Faction == null || (instigator!= null && instigator.Faction == null)))
                 return false;
-            if (DisplayPawnsOnly && !(t is Pawn))
+            if (DisplayPawnsOnly && !(target is Pawn))
                 return false;
             return true;
         }

--- a/Source/ClassLibrary1/Patch.cs
+++ b/Source/ClassLibrary1/Patch.cs
@@ -116,9 +116,9 @@ namespace DamageMotes
         /// <summary>
         /// Used on both the instigator and the target.
         /// </summary>
-        internal static bool ShouldDisplayDamage(this Thing t, Thing instigator = null)
+        internal static bool ShouldDisplayDamage(this Thing target, Thing instigator)
         {
-            return (LoadedModManager.GetMod<DMMod>().settings.ShouldDisplayDamageAccordingToSettings(t)) || (instigator != null && instigator.ShouldDisplayDamage());
+            return (LoadedModManager.GetMod<DMMod>().settings.ShouldDisplayDamageAccordingToSettings(target, instigator));
         }
         public static bool TranspilerUtility_NotifyMiss(bool b, Thing t)
         {


### PR DESCRIPTION
Not exactly sure what the intention was, but it's now simply:

Option to not show if either instigator or target has no faction.
Option to not show if the target is not a pawn.