### PR TITLE
Round the damage numbers when displaying them

### DIFF
--- a/Source/ClassLibrary1/Patch.cs
+++ b/Source/ClassLibrary1/Patch.cs
@@ -24,7 +24,7 @@ namespace DamageMotes
         public static void TakeDamageInfix(Thing instance, DamageWorker.DamageResult result, DamageInfo dinfo)
         {
             float num = result.totalDamageDealt;
-            if (num > 0.01f && instance.Map != null && instance.ShouldDisplayDamage(dinfo.Instigator)) ThrowDamageMote(num, instance.Map, instance.DrawPos, num.ToString());
+            if (num > 0.01f && instance.Map != null && instance.ShouldDisplayDamage(dinfo.Instigator)) ThrowDamageMote(num, instance.Map, instance.DrawPos, Math.Ceiling(num).ToString());
         }
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {


### PR DESCRIPTION
Hi, I found your mod on the Steam Workshop and saw a few comments where people requested that the damage numbers be rounded to prevent it showing damage numbers like `16.66666667`

This should fix that 🙂